### PR TITLE
Add Kindling

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 - **[Grammarly](https://www.grammarly.com/):** Grammarly makes sure everything you type is clear and mistake-free. It even checks for plagiarism.
 - **[The Hemingway Editor](http://www.hemingwayapp.com/):** Hemingway helps you write with power and clarity by highlighting adverbs, passive voice, and dull, complicated words. Cut the dead weight from your writing.
 - **[JigSaw](https://jigsaw.google.com/projects/):** A technology incubator focused on countering extremism and removing censorship online.
+- **[Kindling](https://kindlingwriter.com):** A free, open-source novel writing app that bridges outlining and drafting. Your outline's scene beats become expandable prompts inside a focused drafting space. Built with Rust and Tauri.
 - **[LanguageCheck](https://github.com/JohannesBuchner/languagecheck):** Analyses scientific papers written in LaTeX, offline or on overleaf. Analysis reports with suggestions for improvements include a list of common mistakes/ambiguities, tense consistency, a vs. an, spell check and paragraph topic sentences.
 - **[Markdownlint](https://github.com/markdownlint/markdownlint):** A tool to check markdown files and flag style issues.
   - **[Markdownlint-cli](https://github.com/igorshubovych/markdownlint-cli):** Provides a command line interface for MarkdownLint.


### PR DESCRIPTION
Adds [Kindling](https://kindlingwriter.com) — a free, open-source novel writing app built with Rust and Tauri.

Kindling bridges outlining and drafting: your outline's scene beats become expandable prompts inside a focused drafting space. Available for Windows, macOS, and Linux.

- Website: https://kindlingwriter.com
- - GitHub: https://github.com/smith-and-web/kindling
- - License: MIT