### PR TITLE
Add Inkwell to writing tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 - **[Danger](https://github.com/danger/danger):** Formalizes pull request ettiquette.
 - **[Grammarly](https://www.grammarly.com/):** Grammarly makes sure everything you type is clear and mistake-free. It even checks for plagiarism.
 - **[The Hemingway Editor](http://www.hemingwayapp.com/):** Hemingway helps you write with power and clarity by highlighting adverbs, passive voice, and dull, complicated words. Cut the dead weight from your writing.
+- **[Inkwell](https://github.com/4worlds4w-svg/inkwell):** A lightweight Markdown editor built with Rust and Tauri. Split view, live preview, 4 themes, focus mode, typewriter mode, and version history. No cloud, no accounts, no telemetry.
 - **[JigSaw](https://jigsaw.google.com/projects/):** A technology incubator focused on countering extremism and removing censorship online.
 - **[Kindling](https://kindlingwriter.com):** A free, open-source novel writing app that bridges outlining and drafting. Your outline's scene beats become expandable prompts inside a focused drafting space. Built with Rust and Tauri.
 - **[LanguageCheck](https://github.com/JohannesBuchner/languagecheck):** Analyses scientific papers written in LaTeX, offline or on overleaf. Analysis reports with suggestions for improvements include a list of common mistakes/ambiguities, tense consistency, a vs. an, spell check and paragraph topic sentences.


### PR DESCRIPTION
Adding Inkwell — a lightweight Markdown editor built with Rust and Tauri. Split view, live preview, themes, focus mode, and version history. No cloud, no accounts, no telemetry. Cross-platform (Windows, macOS, Linux).